### PR TITLE
Changed the generated name of request classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ php artisan make:model Post --all
 
 The additional classes/files that will get created for this example are:
 
-* app/Http/Requests/Post/PostStoreRequest.php
-* app/Http/Requests/Post/PostUpdateRequest.php
+* app/Http/Requests/Post/StorePostRequest.php
+* app/Http/Requests/Post/UpdatePostRequest.php
 * app/Policies/PostPolicy.php
 * resources/views/post/create.blade.php
 * resources/views/post/edit.blade.php
@@ -106,8 +106,8 @@ use that instead.
 php artisan make:controller PostController --resource --requests
 ```
 
-Therefore, running the following command will create a PostStoreRequest and
-UpdateRequest class under app/Http/Requests/Post.
+Therefore, running the following command will create a StorePostRequest and
+UpdatePostRequest class under app/Http/Requests/Post.
 
 ##### Create views
 Another option which has been added to the make:controller command is the

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {},
     "autoload": {
         "psr-4": {
-            "BenSherred\\MakeModel\\": "src"
+            "BenSherred\\MakeModel\\": "src/"
         }
     },
     "extra": {

--- a/src/Commands/MakeControllerCommand.php
+++ b/src/Commands/MakeControllerCommand.php
@@ -158,11 +158,11 @@ class MakeControllerCommand extends ControllerMakeCommand
         $model = Str::studly($this->getModelName());
 
         $this->call('make:request', [
-            'name' => "{$controller}/{$model}StoreRequest",
+            'name' => "{$controller}/Store{$model}Request",
         ]);
 
         $this->call('make:request', [
-            'name' => "{$controller}/{$model}UpdateRequest",
+            'name' => "{$controller}/Update{$model}Request",
         ]);
     }
 


### PR DESCRIPTION
In order to make the class names proper in terms of English, the generated names are looking like `StoreModelRequest` and `UpdateModelRequest` now.
*Before it was `ModelStoreRequest` and `ModelUpdateRequest`.*

Still the idea of putting the model name into the request class name (#2) is followed as when the project contains a lot of custom request classes, it is much easier to maintain them with unique names.